### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,24 +15,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.TOOLS_BOT_PAK }}
 
-      - name: Get associated PR
-        uses: helaili/github-graphql-action@2.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
-        with:
-          query: .github/queries/asssociated-pr.query.yml
-          outputFile: pr.json
-          owner: asfadmin
-          name: hyp3-insar-gamma
-          sha: ${{ github.sha }}
-
-      - name: Export PR body
-        id: pr
-        run: |
-          PR_QUERY='.data.repository.commit.associatedPullRequests.edges[0].node.body'
-          PR_BODY=$(jq --raw-output "${PR_QUERY}"  pr.json)
-          echo "::set-output name=body::${PR_BODY}"
-
       - name: Create Release
         uses: actions/create-release@v1
         env:
@@ -40,9 +22,6 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: HyP3 InSAR GAMMA ${{ github.ref }}
-          body: ${{ steps.pr.outputs.body }}
-          draft: false
-          prerelease: false
 
       - name: Attempt fast-forward develop from master
         run: |

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -40,8 +40,9 @@ jobs:
       - name: Safety analysis of conda environment
         shell: bash -l {0}
         run: |
-          python -m pip freeze | safety check --full-report --stdin
-          conda list --export | awk -F '=' '/^[^#]/ {print $1 "==" $2}' | safety check --full-report --stdin
+          # Ignore Safety vulerability #38264, GDAL < 3.1, because GAMMA binaries are built against GDAL 2.*
+          python -m pip freeze | safety check --full-report -i 38264 --stdin
+          conda list --export | awk -F '=' '/^[^#]/ {print $1 "==" $2}' | safety check --full-report -i 38264 --stdin
 
 
   package:
@@ -167,7 +168,7 @@ jobs:
       - name: Add test tag
         if: github.ref == 'refs/heads/develop'
         run: |
-          export SDIST_VERSION=${{needs.package.outputs.SDIST_VERSION}}
+          export SDIST_VERSION=${{ needs.package.outputs.SDIST_VERSION }}
           docker tag ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:${SDIST_VERSION/+/_} \
               ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:test
           docker push ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:test
@@ -175,7 +176,7 @@ jobs:
       - name: Add latest tag
         if: github.ref == 'refs/heads/master'
         run: |
-          export SDIST_VERSION=${{needs.package.outputs.SDIST_VERSION}}
+          export SDIST_VERSION=${{ needs.package.outputs.SDIST_VERSION }}
           docker tag ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:${SDIST_VERSION/+/_} \
               ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:latest
           docker push ${HYP3_REGISTRY}/${GITHUB_REPOSITORY##*/}:latest


### PR DESCRIPTION
Through development of `hyp3-lib` and `hyp3-rtc-gamma` for v2, some tweaks have been made to the workflow. This:

* Simplifies the release workflow
* Fixes some whitespace and types in the workflow yamls
* Ignores Safety's gdal warning b/c we need to keep v2 around for a while